### PR TITLE
Add real-time login session broadcasting via SignalR

### DIFF
--- a/src/Application/Dto/RealTime/LoginSessionDto.cs
+++ b/src/Application/Dto/RealTime/LoginSessionDto.cs
@@ -1,0 +1,6 @@
+namespace Application.Dto.RealTime;
+
+public class LoginSessionDto
+{
+    public required string SessionId { get; set; }
+}

--- a/src/Application/Interface/Broadcast/BroadcastMessage.cs
+++ b/src/Application/Interface/Broadcast/BroadcastMessage.cs
@@ -1,0 +1,11 @@
+namespace Application.Interface.Broadcast;
+
+public class BroadcastMessage
+{
+    public string? Action { get; set; }
+}
+
+public class BroadcastMessage<T> : BroadcastMessage
+{
+    public T? Data { get; set; }
+}

--- a/src/Application/Interface/Broadcast/IBroadcastMessageService.cs
+++ b/src/Application/Interface/Broadcast/IBroadcastMessageService.cs
@@ -1,0 +1,8 @@
+namespace Application.Interface.Broadcast;
+
+public interface IBroadcastMessageService
+{
+    Task SendMessageAsync<T>(string id, BroadcastMessage<T> message) where T : class;
+
+    Task SendMessageToGroupAsync<T>(string groupName, BroadcastMessage<T> message) where T : class;
+}

--- a/src/Domain/Constains/CacheKeys.cs
+++ b/src/Domain/Constains/CacheKeys.cs
@@ -6,6 +6,12 @@ public static class CacheKeys
     {
         public const int IdLength = 15;
         public const int SessionDurationHours = 1;
-        public static string SessionId (string id) => $"session-{id}";
+        public static string SessionId(string id) => $"session-{id}";
+    }
+
+    public struct Login
+    {
+        public static string LoginSessionId(string id) => $"login-session-{id}";
+        public const int LoginDurationMinutes = 2;
     }
 }

--- a/src/Domain/Constains/RealTimeConstants.cs
+++ b/src/Domain/Constains/RealTimeConstants.cs
@@ -1,0 +1,9 @@
+namespace Domain.Constants;
+
+public static class RealTimeConstants
+{
+    public struct Actions
+    {
+        public const string JoinLoginSession = "join-login-session";
+    }
+}

--- a/src/Infrastructure/AddCoreDenpendencies.cs
+++ b/src/Infrastructure/AddCoreDenpendencies.cs
@@ -3,6 +3,7 @@ using Infrastructure.Caching;
 using Infrastructure.DataAccess;
 using Infrastructure.IdGenerator;
 using Infrastructure.MediatR;
+using Infrastructure.Realtime;
 using Infrastructure.Restful;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
@@ -19,5 +20,6 @@ public static class AddCoreDenpendencies
         services.AddRestfulService();
         services.AddIdGenerator();
         services.AddFeatureInjection();
+        services.AddRealTimeServices(configuration);
     }
 }

--- a/src/Infrastructure/Infrastructure.csproj
+++ b/src/Infrastructure/Infrastructure.csproj
@@ -20,5 +20,6 @@
     <PackageReference Include="Nanoid" Version="3.1.0" />
     <PackageReference Include="StackExchange.Redis" Version="2.8.41" />
     <PackageReference Include="Microsoft.Extensions.Caching.StackExchangeRedis" Version="9.0.2" />
+    <PackageReference Include="Microsoft.AspNetCore.SignalR.StackExchangeRedis" Version="8.0.14" />
   </ItemGroup>
 </Project>

--- a/src/Infrastructure/RealTime/BroadcastMessageService.cs
+++ b/src/Infrastructure/RealTime/BroadcastMessageService.cs
@@ -1,0 +1,34 @@
+using System.Diagnostics;
+using System.Linq.Expressions;
+using Application.Dto.RealTime;
+using Application.Interface.Broadcast;
+using Domain.Constants;
+using Domain.Helpers;
+using Infrastructure.RealTime;
+using Microsoft.AspNetCore.SignalR;
+using Microsoft.VisualBasic;
+
+namespace Infrastructure.Realtime;
+
+public class BroadcastMessageService(
+    IHubContext<AuthHub, IAuthHub> authHub
+) : IBroadcastMessageService
+{
+    public Task SendMessageAsync<T>(string id, BroadcastMessage<T> message) where T : class
+    {
+        throw new NotImplementedException();
+    }
+
+    public async Task SendMessageToGroupAsync<T>(string groupName, BroadcastMessage<T> message) where T : class
+    {
+        switch (message.Action)
+        {
+            case RealTimeConstants.Actions.JoinLoginSession:
+                if(message.Data is not LoginSessionDto)
+                    throw new ArgumentException("Invalid login session data");
+
+                await authHub.Clients.Group(groupName).Broadcast(message.ToJson());
+                break;
+        }
+    }
+}

--- a/src/Infrastructure/RealTime/Hubs/AuthHub.cs
+++ b/src/Infrastructure/RealTime/Hubs/AuthHub.cs
@@ -1,0 +1,24 @@
+using Application.Interface.Caching;
+using Infrastructure.RealTime.Hubs;
+using Microsoft.AspNetCore.SignalR;
+
+namespace Infrastructure.RealTime;
+
+public interface IAuthHub : IBaseHub
+{
+}
+
+public class AuthHub : BaseHub<IAuthHub>
+{
+    public async Task JoinLoginSessionChannel(string sessionId)
+    {
+        var connectionId = Context.ConnectionId;
+        await Groups.AddToGroupAsync(connectionId, sessionId);
+    }
+
+    public async Task LeaveLoginSessionChannel(string sessionId)
+    {
+        var connectionId = Context.ConnectionId;
+        await Groups.RemoveFromGroupAsync(connectionId, sessionId);
+    }
+}

--- a/src/Infrastructure/RealTime/Hubs/BaseHub.cs
+++ b/src/Infrastructure/RealTime/Hubs/BaseHub.cs
@@ -1,0 +1,17 @@
+using Microsoft.AspNetCore.SignalR;
+
+namespace Infrastructure.RealTime.Hubs;
+
+public interface IBaseHub
+{
+    /// <summary>
+    ///     Base broadcast method
+    /// </summary>
+    /// <typeparam name="T">Data type</typeparam>
+    /// <param name="message">Data</param>
+    Task Broadcast<T>(T message);
+}
+
+public class BaseHub<T> : Hub<T> where T : class, IBaseHub
+{
+}

--- a/src/Infrastructure/RealTime/RealTimeInjection.cs
+++ b/src/Infrastructure/RealTime/RealTimeInjection.cs
@@ -1,0 +1,36 @@
+using Application.Interface.Broadcast;
+using Domain.Constains;
+using Infrastructure.RealTime;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using StackExchange.Redis;
+
+namespace Infrastructure.Realtime;
+
+public static class RealTimeInjection
+{
+    public static void AddRealTimeServices(this IServiceCollection collection, IConfiguration configuration)
+    {
+        var redisConnectionString = configuration.GetSection(ConfigKeys.Redis.ConnectionString).Get<string>();
+        if (string.IsNullOrEmpty(redisConnectionString))
+        {
+            throw new ArgumentNullException(nameof(redisConnectionString));
+        }
+
+        collection.AddSignalR().AddStackExchangeRedis(redisConnectionString, options =>
+        {
+            options.Configuration.ChannelPrefix = RedisChannel.Literal("AFusion.Orchestrator.Hub_");
+        });
+
+        collection.AddScoped<IBroadcastMessageService, BroadcastMessageService>();
+    }
+
+    public static void AddHub(this WebApplication app)
+    {
+        app.MapHub<AuthHub>("/hubs/auth", options =>
+        {
+            options.CloseOnAuthenticationExpiration = false;
+        });
+    }
+}

--- a/src/Presentation/Configuration/AddSwaggerGen.cs
+++ b/src/Presentation/Configuration/AddSwaggerGen.cs
@@ -20,7 +20,7 @@ public static class AddSwaggerGen
                 Version = "v1",
                 Description = $@"
 👉 **Remember to click 'Authorize' and enter your SessionId.**  
-🔗 GitHub SSO: https://github.com/login/oauth/authorize?client_id={configuration[ConfigKeys.Authorization.GithubSSO.ClientId]}&redirect_uri={configuration[ConfigKeys.Authorization.GithubSSO.CallbackUrl]}&scope=read:user%20user:email&state=
+🔗 GitHub SSO: https://github.com/login/oauth/authorize?client_id={configuration[ConfigKeys.Authorization.GithubSSO.ClientId]}&redirect_uri={configuration[ConfigKeys.Authorization.GithubSSO.CallbackUrl]}&scope=read:user%20user:email&state=Jx8DmnKqJZvNE-
 "
         });
 

--- a/src/Presentation/Controller/v1/AuthController.cs
+++ b/src/Presentation/Controller/v1/AuthController.cs
@@ -21,11 +21,14 @@ public class AuthController : BaseController
     /// </remarks>
     [Route("github-login")]
     [HttpGet]
-    public async Task<IActionResult> GithubLogin(ISender sender, [FromQuery] string code)
+    public async Task<IActionResult> GithubLogin(
+        ISender sender,
+        [FromQuery] string code,
+        [FromQuery] string state)
     {
         var response = new ExecutionRes();
 
-        var errorCode = await sender.Send(new GithubLoginCommand { Code = code });
+        var errorCode = await sender.Send(new GithubLoginCommand { Code = code, State = state });
         if (!string.IsNullOrEmpty(errorCode))
         {
             response.ErrorCode = errorCode;

--- a/src/Presentation/Program.cs
+++ b/src/Presentation/Program.cs
@@ -3,6 +3,7 @@ using Serilog;
 using Infrastructure;
 using Presentation.Configuration;
 using Presentation.Middleware;
+using Infrastructure.Realtime;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -56,6 +57,7 @@ try
 }
 catch { }
 
+app.AddHub();
 app.UseMiddleware<ExceptionHandlingMiddleware>();
 app.MapControllers();
 app.Run();


### PR DESCRIPTION
Introduces real-time infrastructure using SignalR and Redis for broadcasting login session events. Adds DTOs, interfaces, and services for broadcasting messages, updates the GitHub login flow to notify clients when a login session is joined, and wires up SignalR hubs and dependency injection. Also updates Swagger documentation and controller to support the new 'state' parameter for login sessions.